### PR TITLE
Add TLB initialization dance

### DIFF
--- a/tests/cp2/test_cp2_tlb_exception_fill.s
+++ b/tests/cp2/test_cp2_tlb_exception_fill.s
@@ -37,6 +37,8 @@
 #
 
 BEGIN_TEST
+		init_tlb
+
 		# Initialise the in-memory page table to all zeros
 		dli     $t0, 0x9800000001000000
 		li      $t1, 64

--- a/tests/tlb/test_tlb_exception_fill.s
+++ b/tests/tlb/test_tlb_exception_fill.s
@@ -36,6 +36,8 @@
 #
 
 BEGIN_TEST_WITH_CUSTOM_TRAP_HANDLER
+		init_tlb
+
 		# Initialise the in-memory page table to all zeros
 		dli     $t0, 0x9800000001000000
 		li      $t1, 64

--- a/tests/tlb/test_tlb_probe.s
+++ b/tests/tlb/test_tlb_probe.s
@@ -32,6 +32,8 @@
 .include "macros.s"
 
 BEGIN_TEST
+		init_tlb
+
 		li	$t0, 1			# Load counter so that we execute the following test twice,
 						# to check for tlb probe speed.
 		# Fill in a tlb entry and write it

--- a/tests/tlb/test_tlb_user_mode.s
+++ b/tests/tlb/test_tlb_user_mode.s
@@ -29,6 +29,8 @@
 # returning via a system call.
 
 BEGIN_TEST
+		init_tlb
+
 		#
 		# Check to see if we already have a TLB entry for page 0
 		#


### PR DESCRIPTION
The MIPS TLB does not initialize into a well-formed state.  Now that
QEMU is checking for duplicate entries and raising machine checks, we
should get ourselves onto better ground at startup.

Call from all the tests currently throwing machine checks so that they
no longer do.