### PR TITLE
cbuildcap: try to catch inconsistent hidden state

### DIFF
--- a/tests/cp2/test_cp2_cbuildcap.py
+++ b/tests/cp2/test_cp2_cbuildcap.py
@@ -30,6 +30,19 @@ from beritest_tools import attr
 
 class test_cp2_cbuildcap(BaseBERITestCase):
 
+    # This test uses the claimed decode of the capability
     @attr('capabilities')
     def test_cp2_cbuildcap_1(self):
-        self.assertRegisterEqual(self.MIPS.a0, 1, "CBuildCap did not restore capability correctly")
+        assert self.MIPS.c1 == self.MIPS.c3, \
+          "CBuildCap did not restore capability correctly"
+
+    # CEXEQ has access to hidden state (the encoded cr_ebt in QEMU, e.g)
+    @attr('capabilities')
+    def test_cp2_cbuildcap_2(self):
+        assert self.MIPS.a0 == 1, \
+          "CBuildCap did not restore capability correctly (CEXEQ)"
+
+    # Cycling through memory can reveal discrepancies
+    @attr('capabilities')
+    def test_cp2_cbuildcap_3(self):
+        assert self.MIPS.c3 == self.MIPS.c4, "Memory roundtrip not identity"

--- a/tests/cp2/test_cp2_cbuildcap.s
+++ b/tests/cp2/test_cp2_cbuildcap.s
@@ -40,13 +40,17 @@ BEGIN_TEST
 		cgetdefault $c1
 		dla	$t0, data
 		csetoffset $c1, $c1, $t0
-		dli	$t0, 8
+		dli	$t0, 32
 		csetbounds $c1, $c1, $t0
 
 		ccleartag $c2, $c1
 
 		cgetdefault $c3
 		cbuildcap $c3, $c3, $c2
+
+		# Cycle through memory to catch inconsistent metadata
+		csc	$c3, $zero, 0($c1)
+		clc	$c4, $zero, 0($c1)
 
 		cexeq	$a0, $c1, $c3
 


### PR DESCRIPTION
QEMU was failing to update the cr_ebt field in the result of cbuildcap,
inheriting it instead from the authorizing capability.  So long as that
capability remained in the register file, cr_ebt would go unnoticed, but
cycling through memory would restore incorrect bounds (those of the authorozing
capability).